### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29 as build
+FROM fedora:29 as BUILDENV
 RUN dnf --assumeyes install redhat-rpm-config
 RUN dnf --assumeyes install rubygem-bundler
 RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
@@ -18,5 +18,5 @@ RUN bundle install --deployment
 RUN bundle exec yarn install
 RUN bundle exec yarn run build
 
-FROM httpd:2.4
-COPY --from=build /tmp/jsonpath-online-evaluator/dist/ /usr/local/apache2/htdocs/
+FROM nginx:1.15-alpine
+COPY --from=BUILDENV /tmp/jsonpath-online-evaluator/dist/ /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM fedora:29 as build
+RUN dnf --assumeyes install redhat-rpm-config
+RUN dnf --assumeyes install rubygem-bundler
+RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+RUN dnf --assumeyes install yarn
+RUN dnf --assumeyes install git
+RUN dnf --assumeyes group install "C Development Tools and Libraries"
+RUN dnf --assumeyes install ruby-devel
+RUN dnf --assumeyes install libffi-devel
+USER nobody
+WORKDIR /tmp
+RUN git clone https://github.com/ashphy/jsonpath-online-evaluator.git
+WORKDIR jsonpath-online-evaluator
+RUN git checkout 774a9dc
+ENV HOME=/tmp/jsonpath-online-evaluator/home
+RUN mkdir -p $HOME
+RUN bundle install --deployment
+RUN bundle exec yarn install
+RUN bundle exec yarn run build
+
+FROM httpd:2.4
+COPY --from=build /tmp/jsonpath-online-evaluator/dist/ /usr/local/apache2/htdocs/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Artifacts are placed under the `dist`.
   $ yarn run serve
 ```
 
+## Build and run with Docker
+Run on port `8080`.
+
+```
+  $ docker run -it --rm -p 8080:80 $(docker build -q .)
+```
+
 ## Contributing
 
 1. Fork it!


### PR DESCRIPTION
Hi @ashphy please take a look at this. Thanks.

The motivation behind this is:
 - I want to be able to run `jsonpath-online-evaluator` on my local easily without a full development environment.
 - Some people don't feel comfortable pasting JSON data on sites online.